### PR TITLE
feat: 어드민 요금제 대시보드 페이지 header 통일 및 로그아웃 버튼추가

### DIFF
--- a/src/views/DashBoardPage.vue
+++ b/src/views/DashBoardPage.vue
@@ -1,9 +1,7 @@
 <template>
   <div>
     <AdminMenuBar />
-    <header class="list-header">
-      <h1>요금제 대시보드</h1>
-    </header>
+    <CommonHeader title="요금제 대시보드" />
     <div v-if="loading">로딩 중...</div>
     <div v-else-if="!hasData" class="no-data">
       <p>데이터가 없습니다.</p>
@@ -59,6 +57,7 @@ import {
 } from 'chart.js'
 import api from '@/api/axiosInstance'
 import AdminMenuBar from '@/components/AdminMenuBar.vue'
+import CommonHeader from '@/components/CommonHeader.vue'
 
 Chart.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
 


### PR DESCRIPTION
## 🔥 Related Issue

- Close #54 


## 📑 Task

- 어드민 요금제 대시보드 페이지
  - Header 통일
  - 로그아웃 버튼 추가


## 🔍 To Reviewer

- 집중적으로 리뷰해야될 부분 있으면 작성