### PR TITLE
fix: 추가 요금제 정보에서 해당 없음 선택 오류 수정

### DIFF
--- a/src/views/RatePlanAddPage.vue
+++ b/src/views/RatePlanAddPage.vue
@@ -57,8 +57,8 @@
         </div>
         <div class="form-row">
           <div class="form-group">
-            <label>추가 데이터 정보<span class="required">*</span></label>
-            <select v-model="form.extraData" required>
+            <label>추가 데이터 정보</label>
+            <select v-model="form.extraData">
               <option value="">(해당 없음)</option>
               <option value="빠른 데이터(다쓰면 최대 5Mbps)">
                 빠른 데이터(다쓰면 최대 5Mbps)


### PR DESCRIPTION
## 🔥 Related Issue

- Close #89 


## 📑 Task

- 요금제 생성 시 추가 요금제 정보 선택 시 해당 없음 선택 시 오류 수정


## 🔍 To Reviewer